### PR TITLE
Add missing comma in setup function in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ require 'mellifluous'.setup({
     },
     plugins = {
         cmp = true,
-        gitsigns = true
+        gitsigns = true,
         indent_blankline = true,
         nvim_tree = {
             enabled = true,


### PR DESCRIPTION
Line 82
`gitsigns` field was missing it's comma in the README