### PR TITLE
feat(highlights): revamp markup headings, links and raw text

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ require 'mellifluous'.setup({
         properties = {},
         types = {},
         operators = {},
+        markup = {
+            headings = { bold = true },
+        },
     },
     transparent_background = {
         enabled = false,

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ require 'mellifluous'.setup({
 For further instructions, refer to [overriding highlights](#overriding-highlights) section
 
 ##### Extra colors
-In addition to the colors listed in [available colors](#available-colors) section, some color sets may have more colors available (`cyan` and/or `yellow`). To check your color set, refer to [the source code for color sets](lua/mellifluous/colors/sets/) and see if `get_colors_*` functions return any extra (optional) colors.
+In addition to the colors listed in [available colors](#available-colors) section, some color sets may have more colors available (`cyan`). To check your color set, refer to [the source code for color sets](lua/mellifluous/colors/sets/) and see if `get_colors_*` functions return any extra (optional) colors.
 
 ### Overriding highlights
 The following snippet shows how global (for any color set) highlight overrides can be defined:
@@ -250,12 +250,14 @@ Available colors:
     - `green`
     - `blue`
     - `purple`
+    - `yellow`
 - UI colors. Same as named colors, but all are of the same brightness (lightness).
     - `ui_red`: used to indicate errors, deletes, bad spellings.
     - `ui_orange`: used to indicate warnings, changes, other (strange) spellings.
     - `ui_green`: used to indicate staged, additions.
     - `ui_blue`: used to indicate information, new files.
     - `ui_purple`: used to indicate hints, merge.
+    - `ui_yellow`
 
 NOTE: some color sets may have more colors available. See [extra colors](#extra-colors) section.
 

--- a/doc/mellifluous.txt
+++ b/doc/mellifluous.txt
@@ -69,6 +69,9 @@ parts of the config can be included.
             properties = {},
             types = {},
             operators = {},
+            markup = {
+                headings = { bold = true },
+            },
         },
         transparent_background = {
             enabled = false,

--- a/doc/mellifluous.txt
+++ b/doc/mellifluous.txt
@@ -216,10 +216,9 @@ For further instructions, refer to |mellifluous-overriding-highlights| section
 EXTRA COLORS
 
 In addition to the colors listed in |mellifluous-available-colors| section,
-some color sets may have more colors available (`cyan` and/or `yellow`). To
-check your color set, refer to the source code for color sets
-<lua/mellifluous/colors/sets/> and see if `get_colors_*` functions return any
-extra (optional) colors.
+some color sets may have more colors available (`cyan`). To check your color
+set, refer to the source code for color sets <lua/mellifluous/colors/sets/> and
+see if `get_colors_*` functions return any extra (optional) colors.
 
 
 OVERRIDING HIGHLIGHTS        *mellifluous-configuration-overriding-highlights*
@@ -293,12 +292,14 @@ Available colors:
     - `green`
     - `blue`
     - `purple`
+    - `yellow`
 - UI colors. Same as named colors, but all are of the same brightness (lightness).
     - `ui_red`: used to indicate errors, deletes, bad spellings.
     - `ui_orange`: used to indicate warnings, changes, other (strange) spellings.
     - `ui_green`: used to indicate staged, additions.
     - `ui_blue`: used to indicate information, new files.
     - `ui_purple`: used to indicate hints, merge.
+    - `ui_yellow`
 
 NOTE: some color sets may have more colors available. See
 |mellifluous-extra-colors| section.

--- a/lua/mellifluous/colors/sets/alduin.lua
+++ b/lua/mellifluous/colors/sets/alduin.lua
@@ -39,6 +39,7 @@ function M.get_colors_dark(bg)
         green = green, -- staged, additions
         blue = grey, -- information, new files
         purple = cyan, -- hints, merge
+        yellow = strings,
 
         -- optional (for better terminal highlights)
         cyan = cyan,

--- a/lua/mellifluous/colors/sets/mellifluous.lua
+++ b/lua/mellifluous/colors/sets/mellifluous.lua
@@ -78,6 +78,7 @@ function M.get_colors_dark(bg)
         green = green,   -- staged, additions
         blue = blue,     -- information, new files
         purple = purple, -- hints, merge
+        yellow = yellow,
     }
 end
 
@@ -111,6 +112,7 @@ function M.get_colors_light(bg)
         green = green,   -- staged, additions
         blue = blue,     -- information, new files
         purple = purple, -- hints, merge
+        yellow = yellow,
     }
 end
 

--- a/lua/mellifluous/colors/sets/mountain.lua
+++ b/lua/mellifluous/colors/sets/mountain.lua
@@ -35,10 +35,10 @@ function M.get_colors_dark(bg)
         green = green, -- staged, additions
         blue = blue, -- information, new files
         purple = magenta, -- hints, merge
+        yellow = yellow,
 
         -- optional (for better terminal highlights)
         cyan = cyan,
-        yellow = yellow,
     }
 end
 

--- a/lua/mellifluous/colors/sets/tender.lua
+++ b/lua/mellifluous/colors/sets/tender.lua
@@ -44,9 +44,7 @@ function M.get_colors_dark(bg)
         green = green1, -- staged, additions
         blue = blue1, -- information, new files
         purple = blue2, -- hints, merge
-
-        -- optional (for better terminal highlights)
-        yellow = yellow2,
+        yellow = yellow1,
     }
 end
 

--- a/lua/mellifluous/colors/shades.lua
+++ b/lua/mellifluous/colors/shades.lua
@@ -9,6 +9,7 @@ function M.get_recipes()
         ui_green = { target = 'green', action = 'with_li', val = 'ui' },
         ui_blue = { target = 'blue', action = 'with_li', val = 'ui' },
         ui_purple = { target = 'purple', action = 'with_li', val = 'ui' },
+        ui_yellow = { target = 'yellow', action = 'with_li', val = 'ui' },
     }
     local recipes = {}
 

--- a/lua/mellifluous/config.lua
+++ b/lua/mellifluous/config.lua
@@ -34,6 +34,9 @@ local config = {
         properties = {},
         types = {},
         operators = {},
+        markup = {
+            headings = { bold = true }
+        }
     },
     transparent_background = {
         enabled = false,

--- a/lua/mellifluous/highlights/plugins/init.lua
+++ b/lua/mellifluous/highlights/plugins/init.lua
@@ -3,6 +3,8 @@ local M = {}
 function M.set(hl, colors)
     local config = require('mellifluous.config').config
 
+    require('mellifluous.highlights.plugins.treesitter').set(hl, colors)
+
     for plugin in pairs(config.plugins) do
         if (type(config.plugins[plugin]) == 'table' and config.plugins[plugin].enabled == true)
             or (type(config.plugins[plugin]) == 'boolean' and config.plugins[plugin] == true) then
@@ -10,7 +12,6 @@ function M.set(hl, colors)
         end
     end
 
-    require('mellifluous.highlights.plugins.treesitter').set(hl, colors)
     require('mellifluous.highlights.plugins.semantic_tokens').set(hl, colors)
 end
 

--- a/lua/mellifluous/highlights/plugins/treesitter.lua
+++ b/lua/mellifluous/highlights/plugins/treesitter.lua
@@ -94,11 +94,12 @@ function M.set(hl, colors)
     hl.set('@markup.math', { fg = colors.other_keywords })                                    -- Math environments like LaTeX's `$ ... $`
     hl.set('@markup.environment', { fg = colors.other_keywords })                             -- Text environments of markup languages.
     hl.set('@markup.environment.name', { link = '@markup.environment' })                      -- Text/string indicating the type of text environment. Like the name of a `\begin` block in LaTeX.
-    hl.set('@markup.link', { fg = hl.get('@string.special.url').fg })                         -- Footnotes, text references, citations, etc.
-    hl.set('@markup.link.label', { fg = colors.constants })                                   -- Link, reference descriptions
+    hl.set('@markup.link', { fg = colors.constants, style = { underline = true } })           -- Footnotes, text references, citations, etc.
+    hl.set('@markup.link.markdown_inline', { fg = hl.get('@markup.link').fg })                -- Everything in a markdown link that's not a label or url (`[]()`)
+    hl.set('@markup.link.label', { link = '@markup.link' })                                   -- Link, reference descriptions
     hl.set('@markup.link.url', { link = '@string.special.url' })                              -- URIs like hyperlinks or email addresses.
-    hl.set('@markup.raw', { link = 'Character' })                                             -- Literal or verbatim text (e.g., inline code)
-    hl.set('@markup.raw.block', { link = 'Character' })                                       -- Literal or verbatim text as a stand-alone block
+    hl.set('@markup.raw', { fg = colors.fg2 })                                                -- Literal or verbatim text (e.g., inline code)
+    hl.set('@markup.raw.block', { link = '@markup.raw' })                                     -- Literal or verbatim text as a stand-alone block
     hl.set('@markup.list', { link = 'Operator' })                                             -- List markers
     hl.set('@markup.list.unchecked', { link = 'Todo' })                                       -- Unchecked todo-style list markers
     hl.set('@markup.list.checked', { fg = hl.get('@markup.list.unchecked').fg, bg = 'NONE' }) -- Checked todo-style list markers
@@ -108,6 +109,50 @@ function M.set(hl, colors)
     hl.set('@tag', { link = 'Keyword' })                                                      -- Tags like HTML tag names.
     hl.set('@tag.attribute', { link = 'Function', style = {} })                               -- HTML tag attributes.
     hl.set('@tag.delimiter', { link = 'Operator', style = {} })                               -- Tag delimiters like `<` `>` `/`.
+    hl.set('@markup.heading.1.marker', { fg = colors.ui_red, style = {} })
+    hl.set('@markup.heading.2.marker', { fg = colors.ui_orange, style = {} })
+    hl.set('@markup.heading.3.marker', { fg = colors.ui_yellow, style = {} })
+    hl.set('@markup.heading.4.marker', { fg = colors.ui_green, style = {} })
+    hl.set('@markup.heading.5.marker', { fg = colors.ui_blue, style = {} })
+    hl.set('@markup.heading.6.marker', { fg = colors.ui_purple, style = {} })
+    hl.set('@markup.heading.1',
+        {
+            fg = shader.get_higher_contrast(colors.ui_red, 10),
+            bg = colors.bg:with_overlay(colors.ui_red, 16),
+            style = config.styles.markup.headings
+        })
+    hl.set('@markup.heading.2',
+        {
+            fg = shader.get_higher_contrast(colors.ui_orange, 10),
+            bg = colors.bg:with_overlay(colors.ui_orange, 16),
+            style = config.styles.markup.headings
+        })
+    hl.set('@markup.heading.3',
+        {
+            fg = shader.get_higher_contrast(colors.ui_yellow, 10),
+            bg = colors.bg:with_overlay(colors.ui_yellow, 16),
+            style = config.styles.markup.headings
+        })
+    hl.set('@markup.heading.4',
+        {
+            fg = shader.get_higher_contrast(colors.ui_green, 10),
+            bg = colors.bg:with_overlay(colors.ui_green, 16),
+            style = config.styles.markup.headings
+        })
+    hl.set('@markup.heading.5',
+        {
+            fg = shader.get_higher_contrast(colors.ui_blue, 10),
+            bg = colors.bg:with_overlay(colors.ui_blue, 16),
+            style = config.styles.markup.headings
+        })
+    hl.set('@markup.heading.6',
+        {
+            fg = shader.get_higher_contrast(colors.ui_purple, 10),
+            bg = colors.bg:with_overlay(colors.ui_purple, 16),
+            style = config.styles.markup.headings
+        })
+    hl.set('@markup.heading', { link = '@markup.heading.1' })
+    hl.set('@markup.heading.gitcommit', { fg = hl.get('@markup.heading').fg })
 
 
     -- For compatitibilty with older neovim versions (TODO: remove after a few months)

--- a/lua/mellifluous/utils/highlighter.lua
+++ b/lua/mellifluous/utils/highlighter.lua
@@ -11,14 +11,9 @@ local function get_hex(color)
 end
 
 function M.set(name, attributes)
-    if attributes.style then
-        for style_name, val in pairs(attributes.style) do
-            attributes[style_name] = val
-        end
+    if not attributes.style then
+        attributes.style = {}
     end
-    attributes.style = nil
-    attributes.fg = get_hex(attributes.fg)
-    attributes.bg = get_hex(attributes.bg)
 
     highlights[name] = attributes
 end
@@ -33,6 +28,13 @@ end
 
 function M.apply_all()
     for name, attributes in pairs(highlights) do
+        for style_name, val in pairs(attributes.style) do
+            attributes[style_name] = val
+        end
+        attributes.style = nil
+        attributes.fg = get_hex(attributes.fg)
+        attributes.bg = get_hex(attributes.bg)
+
         vim.api.nvim_set_hl(0, name, attributes)
     end
 end


### PR DESCRIPTION
The headings might be a bit controversial, so I'm open to extending the config.

Preview:
![image](https://github.com/ramojus/mellifluous.nvim/assets/41536253/c1fba1c2-111b-4593-bd3f-ccb7c5598e5d)
![image](https://github.com/ramojus/mellifluous.nvim/assets/41536253/571c6485-f507-4ad1-8284-58ba2be17607)

This will also affect vimdoc, and, in the future, neorg.
