### PR TITLE
feat(highlights): neotest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A colorscheme for [Neovim](https://github.com/neovim/neovim). Pleasant and produ
 - [Neorg](https://github.com/nvim-neorg/neorg)
 - [Nvim-notify](https://github.com/rcarriga/nvim-notify)
 - [Aerial](https://github.com/stevearc/aerial.nvim)
+- [Neotest](https://github.com/nvim-neotest/neotest)
 
 ## Installation and usage
 Example with [packer.nvim](https://github.com/wbthomason/packer.nvim):

--- a/lua/mellifluous/config.lua
+++ b/lua/mellifluous/config.lua
@@ -21,6 +21,7 @@ local config = {
         neorg = true,
         nvim_notify = true,
         aerial = true,
+        neotest = true,
     },
     dim_inactive = false,
     styles = {

--- a/lua/mellifluous/highlights/general.lua
+++ b/lua/mellifluous/highlights/general.lua
@@ -48,7 +48,7 @@ function M.set(hl, colors)
             or (config.flat_background.line_numbers and hl.get('Normal').bg)
             or colors.dark_bg
     })                                                                  -- Line number for ':number' and ':#' commands, and when 'number' or 'relativenumber' option is set.
-    hl.set('SignColumn', { link = 'LineNr' })                           -- Column where |signs| are displayed
+    hl.set('SignColumn', { link = 'Normal' })                           -- Column where |signs| are displayed
     hl.set('IncSearch', { bg = colors.other_keywords, fg = colors.bg }) -- 'incsearch' highlighting; also used for the text replaced with ':s///c'
     hl.set('Substitute', { link = 'IncSearch' })                        -- |:substitute| replacement text highlighting
     hl.set('CursorLineNr', {
@@ -204,10 +204,10 @@ function M.set(hl, colors)
     -- DiagnosticFloatingWarn     = { } , -- Used to color 'Warn' diagnostic messages in diagnostics float.
     -- DiagnosticFloatingInfo     = { } , -- Used to color 'Info' diagnostic messages in diagnostics float.
     -- DiagnosticFloatingHint     = { } , -- Used to color 'Hint' diagnostic messages in diagnostics float.
-    hl.set('DiagnosticSignError', { fg = hl.get('DiagnosticError').fg, bg = hl.get('LineNr').bg }) -- Used for 'Error' signs in sign column.
-    hl.set('DiagnosticSignWarn', { fg = hl.get('DiagnosticWarn').fg, bg = hl.get('LineNr').bg })   -- Used for 'Warn' signs in sign column.
-    hl.set('DiagnosticSignInfo', { fg = hl.get('DiagnosticInfo').fg, bg = hl.get('LineNr').bg })   -- Used for 'Info' signs in sign column.
-    hl.set('DiagnosticSignHint', { fg = hl.get('DiagnosticHint').fg, bg = hl.get('LineNr').bg })   -- Used for 'Hint' signs in sign column.
+    hl.set('DiagnosticSignError', { fg = hl.get('DiagnosticError').fg, bg = hl.get('SignColumn').bg }) -- Used for 'Error' signs in sign column.
+    hl.set('DiagnosticSignWarn', { fg = hl.get('DiagnosticWarn').fg, bg = hl.get('SignColumn').bg })   -- Used for 'Warn' signs in sign column.
+    hl.set('DiagnosticSignInfo', { fg = hl.get('DiagnosticInfo').fg, bg = hl.get('SignColumn').bg })   -- Used for 'Info' signs in sign column.
+    hl.set('DiagnosticSignHint', { fg = hl.get('DiagnosticHint').fg, bg = hl.get('SignColumn').bg })   -- Used for 'Hint' signs in sign column.
 end
 
 return M

--- a/lua/mellifluous/highlights/general.lua
+++ b/lua/mellifluous/highlights/general.lua
@@ -48,7 +48,7 @@ function M.set(hl, colors)
             or (config.flat_background.line_numbers and hl.get('Normal').bg)
             or colors.dark_bg
     })                                                                  -- Line number for ':number' and ':#' commands, and when 'number' or 'relativenumber' option is set.
-    hl.set('SignColumn', { link = 'Normal' })                           -- Column where |signs| are displayed
+    hl.set('SignColumn', { link = 'LineNr' })                           -- Column where |signs| are displayed
     hl.set('IncSearch', { bg = colors.other_keywords, fg = colors.bg }) -- 'incsearch' highlighting; also used for the text replaced with ':s///c'
     hl.set('Substitute', { link = 'IncSearch' })                        -- |:substitute| replacement text highlighting
     hl.set('CursorLineNr', {
@@ -204,10 +204,10 @@ function M.set(hl, colors)
     -- DiagnosticFloatingWarn     = { } , -- Used to color 'Warn' diagnostic messages in diagnostics float.
     -- DiagnosticFloatingInfo     = { } , -- Used to color 'Info' diagnostic messages in diagnostics float.
     -- DiagnosticFloatingHint     = { } , -- Used to color 'Hint' diagnostic messages in diagnostics float.
-    hl.set('DiagnosticSignError', { fg = hl.get('DiagnosticError').fg, bg = hl.get('SignColumn').bg }) -- Used for 'Error' signs in sign column.
-    hl.set('DiagnosticSignWarn', { fg = hl.get('DiagnosticWarn').fg, bg = hl.get('SignColumn').bg })   -- Used for 'Warn' signs in sign column.
-    hl.set('DiagnosticSignInfo', { fg = hl.get('DiagnosticInfo').fg, bg = hl.get('SignColumn').bg })   -- Used for 'Info' signs in sign column.
-    hl.set('DiagnosticSignHint', { fg = hl.get('DiagnosticHint').fg, bg = hl.get('SignColumn').bg })   -- Used for 'Hint' signs in sign column.
+    hl.set('DiagnosticSignError', { fg = hl.get('DiagnosticError').fg, bg = hl.get('LineNr').bg }) -- Used for 'Error' signs in sign column.
+    hl.set('DiagnosticSignWarn', { fg = hl.get('DiagnosticWarn').fg, bg = hl.get('LineNr').bg })   -- Used for 'Warn' signs in sign column.
+    hl.set('DiagnosticSignInfo', { fg = hl.get('DiagnosticInfo').fg, bg = hl.get('LineNr').bg })   -- Used for 'Info' signs in sign column.
+    hl.set('DiagnosticSignHint', { fg = hl.get('DiagnosticHint').fg, bg = hl.get('LineNr').bg })   -- Used for 'Hint' signs in sign column.
 end
 
 return M

--- a/lua/mellifluous/highlights/plugins/neotest.lua
+++ b/lua/mellifluous/highlights/plugins/neotest.lua
@@ -1,30 +1,24 @@
 local M = {}
 
-function M.set(hl, colors)
-	local bg = hl.get("SignColumn").bg
-	local config = require("mellifluous.config").config
-
-	if config.is_bg_dark then
-		hl.set("NeotestPassed", { fg = colors.green:with_lightness(40):with_saturation(60), bg = bg })
-		hl.set("NeotestFailed", { fg = colors.red:with_lightness(45):with_saturation(60), bg = bg })
-	else
-		hl.set("NeotestPassed", { fg = colors.green:with_lightness(75):with_saturation(80), bg = bg })
-		hl.set("NeotestFailed", { fg = colors.red:with_lightness(75):with_saturation(80), bg = bg })
-	end
-	hl.set("NeotestRunning", { fg = colors.fg2 })
-	hl.set("NeotestSkipped", { fg = colors.fg })
-	hl.set("NeotestTest", { fg = colors.fg })
-	hl.set("NeotestNamespace", { fg = colors.fg })
-	hl.set("NeotestFocused", { link = "CursorLine" })
-	hl.set("NeotestFile", { fg = colors.fg })
-	hl.set("NeotestDir", { fg = hl.get("Directory").fg })
-	hl.set("NeotestIndent", { fg = colors.fg5 })
-	hl.set("NeotestExpandMarker", { fg = colors.fg })
-	hl.set("NeotestAdapterName", { fg = colors.ui_orange })
-	hl.set("NeotestWinSelect", { fg = colors.fg })
-	hl.set("NeotestMarked", { fg = colors.fg, bg = colors.bg3 })
-	hl.set("NeotestTarget", { fg = colors.fg })
-	hl.set("NeotestUnknown", { fg = colors.fg })
+function M.set(hl)
+  local bg = hl.get('SignColumn').bg
+	hl.set("NeotestAdapterName", { link = "Statement" })
+	hl.set("NeotestBorder", { link = "ColorColumn" })
+	hl.set("NeotestDir", { link = "Number" })
+	hl.set("NeotestExpandMarker", { fg = hl.get("LineNr").fg })
+	hl.set("NeotestFailed", { link = "DiagnosticError", bg = bg })
+	hl.set("NeotestFile", { fg = hl.get("Normal").fg })
+	hl.set("NeotestFocused", { fg = hl.get("Normal").fg, bold = true })
+	-- hl.set("NeotestIndent", {})
+	hl.set("NeotestMarked", { fg = hl.get("Todo").fg, bold = true })
+	hl.set("NeotestNamespace", { link = "Include" })
+	hl.set("NeotestPassed", { link = "Comment", bg = bg })
+	hl.set("NeotestRunning", { link = "Function" })
+	hl.set("NeotestSkipped", { fg = hl.get("MatchParen").fg })
+	-- hl.set("NeotestTarget", {})
+	-- hl.set("NeotestTest", {})
+	hl.set("NeotestUnknown", { link = "DiagnosticWarn" })
+	hl.set("NeotestWinSelect", { fg = hl.get("Todo").fg, bold = true })
 end
 
 return M

--- a/lua/mellifluous/highlights/plugins/neotest.lua
+++ b/lua/mellifluous/highlights/plugins/neotest.lua
@@ -1,0 +1,30 @@
+local M = {}
+
+function M.set(hl, colors)
+	local bg = hl.get("SignColumn").bg
+	local config = require("mellifluous.config").config
+
+	if config.is_bg_dark then
+		hl.set("NeotestPassed", { fg = colors.green:with_lightness(40):with_saturation(60), bg = bg })
+		hl.set("NeotestFailed", { fg = colors.red:with_lightness(45):with_saturation(60), bg = bg })
+	else
+		hl.set("NeotestPassed", { fg = colors.green:with_lightness(75):with_saturation(80), bg = bg })
+		hl.set("NeotestFailed", { fg = colors.red:with_lightness(75):with_saturation(80), bg = bg })
+	end
+	hl.set("NeotestRunning", { fg = colors.fg2 })
+	hl.set("NeotestSkipped", { fg = colors.fg })
+	hl.set("NeotestTest", { fg = colors.fg })
+	hl.set("NeotestNamespace", { fg = colors.fg })
+	hl.set("NeotestFocused", { link = "CursorLine" })
+	hl.set("NeotestFile", { fg = colors.fg })
+	hl.set("NeotestDir", { fg = hl.get("Directory").fg })
+	hl.set("NeotestIndent", { fg = colors.fg5 })
+	hl.set("NeotestExpandMarker", { fg = colors.fg })
+	hl.set("NeotestAdapterName", { fg = colors.ui_orange })
+	hl.set("NeotestWinSelect", { fg = colors.fg })
+	hl.set("NeotestMarked", { fg = colors.fg, bg = colors.bg3 })
+	hl.set("NeotestTarget", { fg = colors.fg })
+	hl.set("NeotestUnknown", { fg = colors.fg })
+end
+
+return M

--- a/lua/mellifluous/highlights/plugins/neotest.lua
+++ b/lua/mellifluous/highlights/plugins/neotest.lua
@@ -1,24 +1,25 @@
 local M = {}
 
-function M.set(hl)
-  local bg = hl.get('SignColumn').bg
-	hl.set("NeotestAdapterName", { link = "Statement" })
-	hl.set("NeotestBorder", { link = "ColorColumn" })
-	hl.set("NeotestDir", { link = "Number" })
-	hl.set("NeotestExpandMarker", { fg = hl.get("LineNr").fg })
-	hl.set("NeotestFailed", { link = "DiagnosticError", bg = bg })
-	hl.set("NeotestFile", { fg = hl.get("Normal").fg })
+function M.set(hl, colors)
+	local config = require("mellifluous.config").config
+
+	hl.set("NeotestAdapterName", { fg = colors.fg3 })
 	hl.set("NeotestFocused", { fg = hl.get("Normal").fg, bold = true })
-	-- hl.set("NeotestIndent", {})
-	hl.set("NeotestMarked", { fg = hl.get("Todo").fg, bold = true })
-	hl.set("NeotestNamespace", { link = "Include" })
-	hl.set("NeotestPassed", { link = "Comment", bg = bg })
-	hl.set("NeotestRunning", { link = "Function" })
-	hl.set("NeotestSkipped", { fg = hl.get("MatchParen").fg })
-	-- hl.set("NeotestTarget", {})
-	-- hl.set("NeotestTest", {})
-	hl.set("NeotestUnknown", { link = "DiagnosticWarn" })
-	hl.set("NeotestWinSelect", { fg = hl.get("Todo").fg, bold = true })
+	hl.set("NeotestTarget", { style = { underline = true } })
+	hl.set("NeotestIndent", { fg = colors.fg4 })
+	hl.set("NeotestExpandMarker", { link = "NeotestIndent" })
+
+	hl.set("NeotestDir", { fg = hl.get("Directory").fg })
+	hl.set("NeotestFile", { fg = colors.fg2 })
+	hl.set("NeotestNamespace", { link = "@namesapce" })
+
+	hl.set("NeotestTest", { fg = colors.fg })
+	hl.set("NeotestRunning", { fg = hl.get("Function").fg })
+	hl.set("NeotestPassed", { link = "@markup.list.checked" })
+	hl.set("NeotestFailed", { fg = colors.ui_red })
+	hl.set("NeotestSkipped", { fg = colors.fg })
+	hl.set("NeotestUnknown", { fg = colors.fg })
+	hl.set("NeotestMarked", { bg = (config.is_bg_dark and colors.bg5) or colors.bg4 })
 end
 
 return M


### PR DESCRIPTION
Disclaimer: I have no clue what I'm doing and just pulled bits in from other support files.

Looks decent but I don't know how to remedy the "chicken/egg" scenario involving the background color of signcolumn vs. the background color of the neotest window.

![neotest](https://github.com/ramojus/mellifluous.nvim/assets/512222/d78e1cff-e683-44ab-a6b5-e710c5a8aaf2)
