### PR TITLE
feat(highlights): add mason support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A colorscheme for [Neovim](https://github.com/neovim/neovim). Pleasant and produ
 - [Aerial](https://github.com/stevearc/aerial.nvim)
 - [Neotest](https://github.com/nvim-neotest/neotest)
 - [Lazy](https://github.com/folke/lazy.nvim)
+- [Mason](https://github.com/williamboman/mason.nvim)
 
 ## Installation and usage
 Example with [packer.nvim](https://github.com/wbthomason/packer.nvim):

--- a/lua/mellifluous/config.lua
+++ b/lua/mellifluous/config.lua
@@ -23,6 +23,7 @@ local config = {
         aerial = true,
         neotest = true,
         lazy = true,
+        mason = true,
     },
     dim_inactive = false,
     styles = {

--- a/lua/mellifluous/highlights/plugins/mason.lua
+++ b/lua/mellifluous/highlights/plugins/mason.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+function M.set(hl, colors)
+    local config = require('mellifluous.config').config
+
+    hl.set('MasonHeader', { fg = colors.dark_bg, bg = colors.ui_orange, bold = true })
+    hl.set('MasonHeaderSecondary', { fg = colors.dark_bg, bg = colors.ui_blue, bold = true })
+    hl.set('MasonHighlightBlockBold', { fg = colors.fg, bg = config.is_bg_dark and colors.bg5 or colors.bg4, bold = true })
+    hl.set('MasonHighlightBlockBoldSecondary', { link = 'MasonHighlightBlockBold' })
+    hl.set('MasonHighlightBlock', { fg = colors.dark_bg, bg = colors.ui_green })
+    hl.set('MasonMutedBlock', { fg = colors.fg2, bg = colors.bg })
+    hl.set('MasonHighlight', { fg = colors.ui_yellow })
+    hl.set('MasonHighlightSecondary', { fg = colors.ui_purple })
+    hl.set('MasonMuted', { fg = colors.fg3 })
+end
+
+return M


### PR DESCRIPTION
Improves the highlighting of [Mason](https://github.com/williamboman/mason.nvim) windows (a popular installer for external tools such as LSP servers), which is inconsistent with the colorscheme by default.

_before_

![mason_before](https://github.com/ramojus/mellifluous.nvim/assets/3299086/8bb0efb4-3b5b-42a1-abc3-66d5e2dfeec4)
![mason_g_before](https://github.com/ramojus/mellifluous.nvim/assets/3299086/e794a5ca-e1a4-4744-949b-a6efe7c42535)

_after_

<details><summary>Outdated screenshots</summary>
<p>

![mason_after](https://github.com/ramojus/mellifluous.nvim/assets/3299086/1d439088-44a1-4faa-8c1e-9b67e22b380c)
![mason_g_after](https://github.com/ramojus/mellifluous.nvim/assets/3299086/48263584-830f-4574-a84f-79b236d9c56c)

</p>
</details>