### PR TITLE
fix(treesitter): set highlight of TSModuleInfo signs

### DIFF
--- a/lua/mellifluous/highlights/plugins/treesitter.lua
+++ b/lua/mellifluous/highlights/plugins/treesitter.lua
@@ -196,6 +196,10 @@ function M.set(hl, colors)
     hl.set("@include", { link = "@keyword.import" })
     hl.set("@repeat", { link = "@keyword.repeat" })
     hl.set("@debug", { link = "@keyword.debug" })
+
+    -- :TSModuleInfo
+    hl.set('TSModuleInfoGood', { fg = colors.ui_green, bold = true })
+    hl.set('TSModuleInfoBad', { fg = colors.ui_red, bold = true })
 end
 
 return M


### PR DESCRIPTION
The default color for signs in the `:TSModuleInfo` view is very bright and inconsistent with the colorscheme.

_before_

![image](https://github.com/ramojus/mellifluous.nvim/assets/3299086/0ec01784-402a-47fc-b831-87f9f49834ff)

_after_

<details><summary>Outdated screenshot</summary>
<p>

![image](https://github.com/ramojus/mellifluous.nvim/assets/3299086/d515ef19-5904-4ac1-ace1-6e587b43cbbb)

</p>
</details> 