### PR TITLE
feat(highlights): add lazy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A colorscheme for [Neovim](https://github.com/neovim/neovim). Pleasant and produ
 - [Nvim-notify](https://github.com/rcarriga/nvim-notify)
 - [Aerial](https://github.com/stevearc/aerial.nvim)
 - [Neotest](https://github.com/nvim-neotest/neotest)
+- [Lazy](https://github.com/folke/lazy.nvim)
 
 ## Installation and usage
 Example with [packer.nvim](https://github.com/wbthomason/packer.nvim):

--- a/lua/mellifluous/config.lua
+++ b/lua/mellifluous/config.lua
@@ -22,6 +22,7 @@ local config = {
         nvim_notify = true,
         aerial = true,
         neotest = true,
+        lazy = true,
     },
     dim_inactive = false,
     styles = {

--- a/lua/mellifluous/highlights/plugins/lazy.lua
+++ b/lua/mellifluous/highlights/plugins/lazy.lua
@@ -1,0 +1,7 @@
+local M = {}
+
+function M.set(hl)
+    hl.set('LazyProgressTodo', { fg = hl.get('LineNr').fg })
+end
+
+return M


### PR DESCRIPTION
Improves highlights for the [lazy.vim](https://github.com/folke/lazy.nvim) plugin manager.

Lazy menus look good out of the box, except for progress bars, which default to `LinrNr`:

![Screenshot 2024-05-23 121520](https://github.com/ramojus/mellifluous.nvim/assets/3299086/6d2cb360-1d63-41e9-b5cb-046d2be658b0)
![Screenshot 2024-05-23 121458](https://github.com/ramojus/mellifluous.nvim/assets/3299086/60c5f023-7dda-4f53-8e2c-faa46e4e51c0)

After introducing the changes from this PR, the progress bar is displayed properly:

![Screenshot 2024-05-23 121723](https://github.com/ramojus/mellifluous.nvim/assets/3299086/e8c21af7-0b02-4509-a8c4-9cc38456621a)