### PR TITLE
fix(general): set highlight of added/removed/changed

### DIFF
--- a/lua/mellifluous/highlights/general.lua
+++ b/lua/mellifluous/highlights/general.lua
@@ -30,6 +30,9 @@ function M.set(hl, colors)
     hl.set('DiffDelete', { bg = colors.bg:with_overlay(colors.ui_red, 15):saturated(20) })    -- Diff mode: Deleted line |diff.txt|
     hl.set('DiffChange', { bg = colors.bg:with_overlay(colors.ui_orange, 15):saturated(20) }) -- Diff mode: Changed line |diff.txt|
     hl.set('DiffText', { bg = colors.bg:with_overlay(colors.ui_orange, 30):saturated(20) })   -- Diff mode: Changed text within a changed line |diff.txt|
+    hl.set('Added', { fg = colors.ui_green })                                                 -- Added text (doc, git, etc.)
+    hl.set('Removed', { fg = colors.ui_red })                                                 -- Removed text (doc, git, etc.)
+    hl.set('Changed', { fg = colors.ui_orange })                                              -- Changed text (doc, git,, etc.)
     hl.set('EndOfBuffer', { fg = colors.bg })                                                 -- Filler lines (~) after the end of the buffer. By default, this is highlighted like |hl-NonText|.
     hl.set('TermCursor', { link = 'Cursor' })                                                 -- Cursor in a focused terminal
     hl.set('TermCursorNC', { bg = colors.fg5 })                                               -- Cursor in an unfocused terminal


### PR DESCRIPTION
Neovim declares the core highlight groups `Added`. `Changed` and `Removed`. Those are used in some cases instead of their `Diff*` counterpart, for example while editing Git hunks during a `git add --patch`, or in docs/changelogs, etc.

The current defaults are very bright, and inconsistent with the colorscheme:

![before](https://github.com/ramojus/mellifluous.nvim/assets/3299086/c273618a-e571-402e-8b04-025acbf56dd7)

After the changes from this PR:

<details><summary>Outdated screenshots</summary>
<p>

![after](https://github.com/ramojus/mellifluous.nvim/assets/3299086/8f1c5178-15a2-438e-a28d-cc736a243ae3)
![vimhelp](https://github.com/ramojus/mellifluous.nvim/assets/3299086/68cfb4b7-7dc0-4ffa-9402-402f3f6440a4)

</p>
</details> 