### PR TITLE
feat(highlights): colored underlined LSP diagnostics

### DIFF
--- a/lua/mellifluous/highlights/general.lua
+++ b/lua/mellifluous/highlights/general.lua
@@ -199,10 +199,11 @@ function M.set(hl, colors)
         bg = (config.transparent_background.enabled and 'NONE') or
             colors.bg:with_overlay(hl.get('DiagnosticHint').fg, 12)
     })                                                       -- Used for 'Hint' diagnostic virtual text.
-    hl.set('DiagnosticUnderlineError', { underline = true }) -- Used to underline 'Error' diagnostics.
-    hl.set('DiagnosticUnderlineWarn', { underline = true })  -- Used to underline 'Warn' diagnostics.
-    hl.set('DiagnosticUnderlineInfo', { underline = true })  -- Used to underline 'Info' diagnostics.
-    hl.set('DiagnosticUnderlineHint', { underline = true })  -- Used to underline 'Hint' diagnostics.
+    hl.set('DiagnosticUnderlineError', { underline = true, sp = hl.get('DiagnosticError').fg }) -- Used to underline 'Error' diagnostics.
+    hl.set('DiagnosticUnderlineWarn', { underline = true, sp = hl.get('DiagnosticWarn').fg })   -- Used to underline 'Warn' diagnostics.
+    hl.set('DiagnosticUnderlineHint', { underline = true, sp = hl.get('DiagnosticHint').fg })   -- Used to underline 'Hint' diagnostics.
+    hl.set('DiagnosticUnderlineInfo', { underline = true, sp = hl.get('DiagnosticInfo').fg })   -- Used to underline 'Info' diagnostics.
+    hl.set('DiagnosticUnnecessary', { underline = true })                                       -- Used to underline unnecessary or unused code.
     -- DiagnosticFloatingError    = { } , -- Used to color 'Error' diagnostic messages in diagnostics float. See |vim.diagnostic.open_float()|
     -- DiagnosticFloatingWarn     = { } , -- Used to color 'Warn' diagnostic messages in diagnostics float.
     -- DiagnosticFloatingInfo     = { } , -- Used to color 'Info' diagnostic messages in diagnostics float.

--- a/lua/mellifluous/utils/highlighter.lua
+++ b/lua/mellifluous/utils/highlighter.lua
@@ -34,6 +34,7 @@ function M.apply_all()
         attributes.style = nil
         attributes.fg = get_hex(attributes.fg)
         attributes.bg = get_hex(attributes.bg)
+        attributes.sp = get_hex(attributes.sp)
 
         vim.api.nvim_set_hl(0, name, attributes)
     end


### PR DESCRIPTION
By default, Neovim uses a color to underline LSP diagnostics. The color matches the severity of the diagnostic, and is very useful to be able to quickly identify multiple diagnostic severities appearing on the same line:

![image](https://github.com/ramojus/mellifluous.nvim/assets/3299086/069c8d09-de9c-41bc-9ad8-981b9869915e)

The colorscheme currently doesn't color underlined LSP diagnostics. The example below isn't particularly realistic, but I encountered the case multiple times in Go and Rust codebases, and had to jump to each diagnostic individually (or call `vim.diagnostic.open_float()`) to be able to identify their severity:

![Screenshot 2024-05-25 091624](https://github.com/ramojus/mellifluous.nvim/assets/3299086/dbf9ead2-58cc-4700-813b-4d2a81bbf1d8)

After the changes from this PR, colored underlines are restored:

![Screenshot 2024-05-25 091536](https://github.com/ramojus/mellifluous.nvim/assets/3299086/18cefeb5-ae7c-4115-8696-3a0e3ee0f674)