### PR TITLE
fix(colors): increase contrast for dark bg layers

### DIFF
--- a/lua/mellifluous/colors/shades.lua
+++ b/lua/mellifluous/colors/shades.lua
@@ -21,9 +21,9 @@ function M.get_recipes()
             fg5 = { target = 'fg', action = 'da', val = 54 },
             dark_bg = { target = 'bg', action = 'da', val = 2.5 },
             bg2 = { target = 'bg', action = 'li', val = 4 },
-            bg3 = { target = 'bg', action = 'li', val = 6 },
-            bg4 = { target = 'bg', action = 'li', val = 8 },
-            bg5 = { target = 'bg', action = 'li', val = 10 },
+            bg3 = { target = 'bg', action = 'li', val = 7 },
+            bg4 = { target = 'bg', action = 'li', val = 10 },
+            bg5 = { target = 'bg', action = 'li', val = 13 },
         }
     else
         recipes = {


### PR DESCRIPTION
before:
![image](https://github.com/ramojus/mellifluous.nvim/assets/41536253/59998eba-eedb-440e-8986-c0bbc9db307e)
after:
![image](https://github.com/ramojus/mellifluous.nvim/assets/41536253/a6859b09-9361-4524-9813-e194fca35e88)
compared to light bg:
![image](https://github.com/ramojus/mellifluous.nvim/assets/41536253/47342159-6db2-4bfb-a87c-8d2d46367a1f)

Related to #39
