### PR TITLE
refactor(colors): simplify creation and replication of shades

### DIFF
--- a/lua/mellifluous/color.lua
+++ b/lua/mellifluous/color.lua
@@ -86,6 +86,10 @@ function color_meta:with_saturation(val)
     return M.new(okhsl_to_hex(okhsl))
 end
 
+function color_meta:get_hsl()
+    return hex_to_okhsl(self.hex)
+end
+
 function M.color_set_to_hsl(colors)
     for name, color in pairs(colors) do
         local okhsl = hex_to_okhsl(color.hex)

--- a/lua/mellifluous/colors/init.lua
+++ b/lua/mellifluous/colors/init.lua
@@ -71,8 +71,7 @@ function M.get_colors()
 
     tbl_extend_non_nil(colors, color_overrides)
 
-    local shade_recipes = require'mellifluous.colors.shades'.get_recipes()
-    colors = require 'mellifluous.utils.shader'.add_shades(shade_recipes, colors)
+    colors = require'mellifluous.colors.shades'.extend_with_shades(colors)
 
     return colors
 end

--- a/lua/mellifluous/colors/shades.lua
+++ b/lua/mellifluous/colors/shades.lua
@@ -1,46 +1,48 @@
 local M = {}
 
-function M.get_recipes()
+function M.extend_with_shades(colors)
     local config = require('mellifluous.config').config
 
-    local shared_recipes = {
-        ui_red = { target = 'red', action = 'with_li', val = 'ui' },
-        ui_orange = { target = 'orange', action = 'with_li', val = 'ui' },
-        ui_green = { target = 'green', action = 'with_li', val = 'ui' },
-        ui_blue = { target = 'blue', action = 'with_li', val = 'ui' },
-        ui_purple = { target = 'purple', action = 'with_li', val = 'ui' },
-        ui_yellow = { target = 'yellow', action = 'with_li', val = 'ui' },
+    local shared_shades = {
+        ui_red = colors.red:with_lightness(config.ui_color_base_lightness),
+        ui_orange = colors.orange:with_lightness(config.ui_color_base_lightness),
+        ui_green = colors.green:with_lightness(config.ui_color_base_lightness),
+        ui_blue = colors.blue:with_lightness(config.ui_color_base_lightness),
+        ui_purple = colors.purple:with_lightness(config.ui_color_base_lightness),
+        ui_yellow = colors.yellow:with_lightness(config.ui_color_base_lightness),
     }
-    local recipes = {}
+
+    local shades = {}
+    local fg = colors.shades_fg or colors.fg
 
     if config.is_bg_dark then
-        recipes = {
-            fg2 = { target = 'fg', action = 'da', val = 16 },
-            fg3 = { target = 'fg', action = 'da', val = 32 },
-            fg4 = { target = 'fg', action = 'da', val = 48 },
-            fg5 = { target = 'fg', action = 'da', val = 54 },
-            dark_bg = { target = 'bg', action = 'da', val = 2.5 },
-            bg2 = { target = 'bg', action = 'li', val = 4 },
-            bg3 = { target = 'bg', action = 'li', val = 7 },
-            bg4 = { target = 'bg', action = 'li', val = 10 },
-            bg5 = { target = 'bg', action = 'li', val = 13 },
+        shades = {
+            fg2 = fg:darkened(16),
+            fg3 = fg:darkened(32),
+            fg4 = fg:darkened(48),
+            fg5 = fg:darkened(54),
+            dark_bg = colors.bg:darkened(2.5),
+            bg2 = colors.bg:lightened(4),
+            bg3 = colors.bg:lightened(7),
+            bg4 = colors.bg:lightened(10),
+            bg5 = colors.bg:lightened(13),
         }
     else
-        recipes = {
-            fg2 = { target = 'fg', action = 'li', val = 16 },
-            fg3 = { target = 'fg', action = 'li', val = 32 },
-            fg4 = { target = 'fg', action = 'li', val = 48 },
-            fg5 = { target = 'fg', action = 'li', val = 54 },
-            dark_bg2 = { target = 'bg', action = 'da', val = 8 },
-            dark_bg = { target = 'bg', action = 'da', val = 2.5 },
-            bg2 = { target = 'bg', action = 'li', val = 4 },
-            bg3 = { target = 'bg', action = 'li', val = 6 },
-            bg4 = { target = 'bg', action = 'li', val = 8 },
+        shades = {
+            fg2 = fg:lightened(16),
+            fg3 = fg:lightened(32),
+            fg4 = fg:lightened(48),
+            fg5 = fg:lightened(54),
+            dark_bg2 = colors.bg:darkened(8),
+            dark_bg = colors.bg:darkened(2.5),
+            bg2 = colors.bg:lightened(4),
+            bg3 = colors.bg:lightened(6),
+            bg4 = colors.bg:lightened(8),
         }
     end
 
-    recipes = vim.tbl_extend('force', recipes, shared_recipes)
-    return recipes
+    colors = vim.tbl_extend('force', colors, shared_shades)
+    return vim.tbl_extend('force', colors, shades)
 end
 
 return M

--- a/lua/mellifluous/highlights/general.lua
+++ b/lua/mellifluous/highlights/general.lua
@@ -2,7 +2,6 @@ local M = {}
 
 function M.set(hl, colors)
     local shader = require('mellifluous.utils.shader')
-    local shade_recipes = require('mellifluous.colors.shades').get_recipes()
     local config = require('mellifluous.config').config
 
     hl.set('Normal', {
@@ -58,7 +57,7 @@ function M.set(hl, colors)
         bg = (config.flat_background.cursor_line_number and hl.get('LineNr').bg)
             or (config.flat_background.line_numbers and hl.get('CursorLine').bg)
             or (config.transparent_background.enabled and 'NONE')
-            or shader.get_shade(shade_recipes.dark_bg, hl.get('CursorLine').bg),
+            or shader.replicate_shade(colors.bg, colors.dark_bg, hl.get('CursorLine').bg),
         fg = hl.get('LineNr').fg
     })                                                                   -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
     hl.set('MatchParen', { bg = colors.bg4, fg = colors.main_keywords }) -- Character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|

--- a/lua/mellifluous/utils/shader.lua
+++ b/lua/mellifluous/utils/shader.lua
@@ -8,6 +8,8 @@ function M.replicate_shade(from_color, to_color, target)
     local target_hsl = target:get_hsl()
     if target_hsl.h and from_hsl.h and to_hsl.h then
         target_hsl.h = target_hsl.h + to_hsl.h - from_hsl.h
+    elseif from_hsl.h ~= to_hsl.h then
+        require('mellifluous').return_error('this shade changes hue, but at least one of the colors is neutral, without hue')
     end
     target_hsl.s = target_hsl.s + to_hsl.s - from_hsl.s
     target_hsl.l = target_hsl.l + to_hsl.l - from_hsl.l

--- a/lua/mellifluous/utils/shader.lua
+++ b/lua/mellifluous/utils/shader.lua
@@ -1,37 +1,18 @@
 local M = {}
 
-function M.get_shade(recipe, target_color)
-    local config = require('mellifluous.config').config
-    local color
-    if type(target_color) == 'string' then -- hex
-        color = require'mellifluous.color'.new(target_color)
-    else
-        color = target_color
+function M.replicate_shade(from_color, to_color, target)
+    local from_hsl = from_color:get_hsl()
+    local to_hsl = to_color:get_hsl()
+    local color = require('mellifluous.color')
+
+    local target_hsl = target:get_hsl()
+    if target_hsl.h and from_hsl.h and to_hsl.h then
+        target_hsl.h = target_hsl.h + to_hsl.h - from_hsl.h
     end
+    target_hsl.s = target_hsl.s + to_hsl.s - from_hsl.s
+    target_hsl.l = target_hsl.l + to_hsl.l - from_hsl.l
 
-    local val = recipe.val == 'ui' and config.ui_color_base_lightness or recipe.val
-
-    if recipe.action == 'li' then
-        return color:lightened(val)
-    elseif recipe.action == 'da' then
-        return color:darkened(val)
-    elseif recipe.action == 'with_li' then
-        return color:with_lightness(val)
-    else
-        require('mellifluous').return_error("unknwon shade recipe action: " .. recipe.action)
-    end
-end
-
-function M.add_shades(shade_recipes, colors)
-    local fg = colors.shades_fg or colors.fg
-    local shaded_colors = {}
-
-    for shaded_color_name, recipe in pairs(shade_recipes) do
-        local target_color = recipe.target == 'fg' and fg or colors[recipe.target]
-        shaded_colors[shaded_color_name] = M.get_shade(recipe, target_color)
-    end
-
-    return vim.tbl_deep_extend("keep", colors, shaded_colors)
+    return color.new_from_hsl(target_hsl)
 end
 
 function M.get_lower_contrast(color, amount)


### PR DESCRIPTION
Instead of relying on shade recipes, one can now replicate a shade from any two colors, thus, shade recipes are no longer needed.