### PR TITLE
fix(plugins): prevent error when transparent bg is enabled

### DIFF
--- a/lua/mellifluous/highlights/plugins/lazy.lua
+++ b/lua/mellifluous/highlights/plugins/lazy.lua
@@ -3,11 +3,13 @@ local M = {}
 function M.set(hl, colors)
     local config = require("mellifluous.config").config
     local groups = require("mellifluous.highlights.custom_groups").get(colors)
-    local bg = hl.get("NormalFloat").bg
+
+    local f_bg = hl.get("NormalFloat").bg
+    local bg_active = (type(f_bg) == "string" and f_bg == "NONE") and colors.bg3 or f_bg
 
     hl.set("LazyNormal", { bg = colors.bg2 })
     hl.set("LazyButton", groups.MenuButton)
-    hl.set("LazyButtonActive", groups.MenuButtonSelected(bg))
+    hl.set("LazyButtonActive", groups.MenuButtonSelected(bg_active))
     hl.set("LazyH1", { link = "LazyButtonActive" })
 
     hl.set("LazyProgressTodo", { fg = config.is_bg_dark and colors.fg5 or colors.dark_bg })

--- a/lua/mellifluous/highlights/plugins/mason.lua
+++ b/lua/mellifluous/highlights/plugins/mason.lua
@@ -2,7 +2,9 @@ local M = {}
 
 function M.set(hl, colors)
     local groups = require("mellifluous.highlights.custom_groups").get(colors)
+
     local bg = hl.get("NormalFloat").bg
+    bg = (type(bg) == "string" and bg == "NONE") and colors.bg3 or bg
 
     hl.set("MasonHeader", { fg = colors.dark_bg, bg = colors.ui_orange, bold = true })
     hl.set("MasonHeaderSecondary", { fg = colors.dark_bg, bg = colors.ui_blue, bold = true })


### PR DESCRIPTION
My proposal to fix #47 with a non- over-engineered solution.

Do not attempt to pass the "NONE" string to `shader.replicate_shade()` via `groups.MenuButtonSelected()`. Instead, fall back to a sane default.

Alternatively, a check + fallback could be added inside [`groups.MenuButtonSelected()`](https://github.com/ramojus/mellifluous.nvim/blob/1d4884d64b0ebd685f418c29eeb4274f3688eecc/lua/mellifluous/highlights/custom_groups.lua#L24-L26) directly, but this would prevent callers (e.g. plugin customizations) from picking their own default.

---

### A few screen captures 🖼️

Normal buffer
<img width="1113" alt="Screenshot 2024-07-30 at 14 20 20" src="https://github.com/user-attachments/assets/bb17aa23-689d-418a-8c8c-c2c96eeccd5e">
Mason
<img width="1113" alt="Screenshot 2024-07-30 at 14 20 15" src="https://github.com/user-attachments/assets/899ba193-5b97-443f-b2cb-16080c670d69">
Lazy (does not use `NormalFloat`, interestingly)
<img width="1113" alt="Screenshot 2024-07-30 at 14 20 03" src="https://github.com/user-attachments/assets/e4d703cc-addb-4cc3-8ceb-37ebca37dfd3">

Light background
<img width="1113" alt="Screenshot 2024-07-30 at 14 21 26" src="https://github.com/user-attachments/assets/3a0c66d7-7d37-4aef-8909-93ae7dc1ed47">