### PR TITLE
fix(lazy): use NormalFloat bg as bg

### DIFF
--- a/lua/mellifluous/highlights/plugins/lazy.lua
+++ b/lua/mellifluous/highlights/plugins/lazy.lua
@@ -5,7 +5,7 @@ function M.set(hl, colors)
     local groups = require("mellifluous.highlights.custom_groups").get(colors)
     local bg = hl.get("NormalFloat").bg
 
-    hl.set("LazyNormal", { bg = colors.bg2 })
+    hl.set("LazyNormal", { bg = bg })
     hl.set("LazyButton", groups.MenuButton)
     hl.set("LazyButtonActive", groups.MenuButtonSelected(bg))
     hl.set("LazyH1", { link = "LazyButtonActive" })


### PR DESCRIPTION
I've decided to use bg2 for lazy in #37 (instead of `NormalFloat` - bg3) to make the buttons look more pronounced. The design of the buttons has since been generalized to look good in all contexts (#44) and lazy bg became an issue, because it was inconsistent with other plugins without any real reason.
Furthermore, bg2 doesn't respect transparent_background setting, so we should always use `NormalFloat` bg, which respects this setting.

Fix was attempted in #49, but this PR keeps the inconsistency, which I would prefer to get rid of.

Fixes #51.