### PR TITLE
fix(config): rebase on default config after changes from CLI

### DIFF
--- a/lua/mellifluous/config.lua
+++ b/lua/mellifluous/config.lua
@@ -1,64 +1,68 @@
 local M = {}
+local config = {}
+local saved_user_config = {}
 
-local config = {
-    color_set = "mellifluous",
-    plugins = {
-        cmp = true,
-        indent_blankline = true,
-        nvim_tree = {
-            enabled = true,
-            show_root = false,
+local function get_default_config()
+    return {
+        color_set = "mellifluous",
+        plugins = {
+            cmp = true,
+            indent_blankline = true,
+            nvim_tree = {
+                enabled = true,
+                show_root = false,
+            },
+            neo_tree = {
+                enabled = true,
+            },
+            telescope = {
+                enabled = true,
+                nvchad_like = true,
+            },
+            startify = true,
+            gitsigns = true,
+            neorg = true,
+            nvim_notify = true,
+            aerial = true,
+            neotest = true,
+            lazy = true,
+            mason = true,
         },
-        neo_tree = {
-            enabled = true,
+        dim_inactive = false,
+        styles = {
+            comments = { italic = true },
+            conditionals = {},
+            folds = {},
+            loops = {},
+            functions = {},
+            keywords = {},
+            strings = {},
+            variables = {},
+            numbers = {},
+            booleans = {},
+            properties = {},
+            types = {},
+            operators = {},
+            markup = {
+                headings = { bold = true },
+            },
         },
-        telescope = {
-            enabled = true,
-            nvchad_like = true,
+        transparent_background = {
+            enabled = false,
+            floating_windows = true,
+            telescope = true,
+            file_tree = true,
+            cursor_line = true,
+            status_line = false,
         },
-        startify = true,
-        gitsigns = true,
-        neorg = true,
-        nvim_notify = true,
-        aerial = true,
-        neotest = true,
-        lazy = true,
-        mason = true,
-    },
-    dim_inactive = false,
-    styles = {
-        comments = { italic = true },
-        conditionals = {},
-        folds = {},
-        loops = {},
-        functions = {},
-        keywords = {},
-        strings = {},
-        variables = {},
-        numbers = {},
-        booleans = {},
-        properties = {},
-        types = {},
-        operators = {},
-        markup = {
-            headings = { bold = true },
+        flat_background = {
+            line_numbers = false,
+            floating_windows = false,
+            file_tree = false,
+            cursor_line_number = false,
         },
-    },
-    transparent_background = {
-        enabled = false,
-        floating_windows = true,
-        telescope = true,
-        file_tree = true,
-        cursor_line = true,
-        status_line = false,
-    },
-    flat_background = {
-        line_numbers = false,
-        floating_windows = false,
-        file_tree = false,
-        cursor_line_number = false,
-    },
-}
+    }
+end
 
 local function disable_disabled()
     for _, v in pairs(config) do
@@ -76,27 +80,25 @@ end
 
 local are_color_set_defaults_merged = false
 
-local function merge_color_set_defaults()
+local function merge_color_set_defaults(color_set)
     if are_color_set_defaults_merged then
         return
     end
     are_color_set_defaults_merged = true
 
-    local color_set = require("mellifluous.colors.sets." .. config.color_set)
+    local color_set_module = require("mellifluous.colors.sets." .. color_set)
 
-    if not color_set.get_config then
+    if not color_set_module.get_config then
         return
     end
 
-    config[config.color_set] = vim.tbl_deep_extend("force", config[config.color_set] or {}, color_set.get_config())
+    config[color_set] = vim.tbl_deep_extend("force", config[color_set] or {}, color_set_module.get_config())
 end
 
 local function process_color_set()
     config.is_bg_dark = require("mellifluous.colors").get_is_bg_dark(config.color_set)
     config.ui_color_base_lightness =
         require("mellifluous.colors").get_ui_color_base_lightness(config.color_set, config.is_bg_dark)
-
-    merge_color_set_defaults()
 end
 
 -- https://www.lua.org/pil/13.4.5.html
@@ -113,11 +115,14 @@ local function read_only(table)
 end
 
 function M.setup(user_config)
-    merge_color_set_defaults()
-    config = vim.tbl_deep_extend("force", config, user_config or {})
+    saved_user_config = vim.tbl_deep_extend("force", saved_user_config, user_config)
 end
 
 function M.prepare()
+    config = get_default_config()
+    merge_color_set_defaults(vim.tbl_get(saved_user_config, "color_set") or config.color_set)
+    config = vim.tbl_deep_extend("force", config, saved_user_config or {})
+
     process_color_set()
     disable_disabled()
 


### PR DESCRIPTION
CLI commands update the config and reload the colorscheme. The problem is that the config gets modified for easier usage on first load of the colorscheme (via [disable_disabled](https://github.com/ramojus/mellifluous.nvim/blob/b18fef92193d341a3252efcd6d92c4ae2257b535/lua/mellifluous/config.lua#L63-L75) function). Because of this, CLI commands work differently from modifying the config directly (e.g. if `:Mellifluous toggle_transparency` command would enable transparency, the suboptions of `transparent_background` would still be disabled from earlier colorscheme load).

This PR preserves default config (with `get_default_config` function) so that it can be recovered whenever user modifies the config with CLI. For this to work, all user config is saved separately between different loads of the colorscheme.