### PR TITLE
Initial support for Oil file manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A colorscheme for [Neovim](https://github.com/neovim/neovim). Pleasant and produ
 - [Neotest](https://github.com/nvim-neotest/neotest)
 - [Lazy](https://github.com/folke/lazy.nvim)
 - [Mason](https://github.com/williamboman/mason.nvim)
+- [Oil](https://github.com/stevearc/oil.nvim)
 
 ## Installation and usage
 Example with [packer.nvim](https://github.com/wbthomason/packer.nvim):

--- a/lua/mellifluous/config.lua
+++ b/lua/mellifluous/config.lua
@@ -27,6 +27,7 @@ local function get_default_config()
             neotest = true,
             lazy = true,
             mason = true,
+            oil = true,
         },
         dim_inactive = false,
         styles = {

--- a/lua/mellifluous/highlights/plugins/oil.lua
+++ b/lua/mellifluous/highlights/plugins/oil.lua
@@ -1,0 +1,9 @@
+local M = {}
+
+function M.set(hl, colors)
+    local config = require("mellifluous.config").config
+
+    hl.set("OilDir", { fg = (config.is_bg_dark and colors.ui_yellow) or hl.get("Directory").fg })
+end
+
+return M


### PR DESCRIPTION
Hello again

I've been using [oil](https://github.com/stevearc/oil.nvim) for some time now configured to avoid displaying icons.

![oil-orig](https://github.com/user-attachments/assets/c8b71a33-7877-48c9-a93b-39aaba39cf06)

Out of nowhere, I started to wonder if I'd enjoy having directories made a bit more distinct via some coloring. This is the result.

![oil-new](https://github.com/user-attachments/assets/f0a4431b-22d9-4682-a728-4b5b51fa8850)

^ ignore that blue line on the left as it is from my window manager.

Oil doesn't have many [highlights](https://github.com/stevearc/oil.nvim/blob/1fe476daf0b3c108cb8ee1fc1226cc282fa2c9c1/doc/oil.txt#L577) so I figure this will be easy to extend as needed. I also tried to limit this to a dark background as I'd guess it would look horrible against something light.

Also, I really have no strong preference for `ui_yellow` but stuck with it after I saw it take effect.

