### PR TITLE
fix(highlights): improve `Pmenu` readability

### DIFF
--- a/lua/mellifluous/highlights/general.lua
+++ b/lua/mellifluous/highlights/general.lua
@@ -82,8 +82,8 @@ function M.set(hl, colors)
     })
     hl.set("FloatTitle", { bg = hl.get("NormalFloat").bg, fg = colors.comments })
     hl.set("FloatShadow", { bg = colors.dark_bg })
-    hl.set("Pmenu", { bg = colors.bg4, fg = config.is_bg_dark and colors.fg3 or colors.fg4 }) -- Popup menu: Normal item.
-    hl.set("PmenuSel", { bg = config.is_bg_dark and colors.fg5 or colors.dark_bg }) -- Popup menu: Selected item.
+    hl.set("Pmenu", { bg = colors.bg3, fg = config.is_bg_dark and colors.fg3 or colors.fg4 }) -- Popup menu: Normal item.
+    hl.set("PmenuSel", { bg = groups.MenuButtonSelected(colors.bg3).bg }) -- Popup menu: Selected item.
     hl.set("PmenuSbar", { bg = colors.bg3 }) -- Popup menu: Scrollbar.
     hl.set("PmenuThumb", { bg = colors.fg5 }) -- Popup menu: Thumb of the scrollbar.
     hl.set("Question", { fg = colors.other_keywords }) -- |hit-enter| prompt and yes/no questions


### PR DESCRIPTION
Prompted by https://github.com/ramojus/mellifluous.nvim/discussions/69
Just aligned it more with how every other element in the colorscheme is colored -- `colors.bg3` as a background for floating window, `custom_groups.MenuButtonSelected` background as a background for the selected item.