### PR TITLE
feat(config): add lightness option for transparent bg

### DIFF
--- a/lua/mellifluous/colors/init.lua
+++ b/lua/mellifluous/colors/init.lua
@@ -112,6 +112,13 @@ function M.get_colors()
 
     colors = apply_color_overrides(colors)
     ensure_correct_color_types(colors)
+    if
+        config.transparent_background
+        and config.transparent_background.lightness
+        and type(config.transparent_background.lightness) == "function"
+    then
+        colors.bg = colors.bg:with_lightness(config.transparent_background.lightness(colors.bg))
+    end
 
     colors = require("mellifluous.colors.shades").extend_with_shades(colors)
 

--- a/lua/mellifluous/config.lua
+++ b/lua/mellifluous/config.lua
@@ -45,6 +45,25 @@ local function get_default_config()
         },
         transparent_background = {
             enabled = false,
+            lightness = function(bg) -- used for bg shades
+                -- This method tries to keep brighter colorsets bright and
+                -- dimmer colorsets dim and still lighten the shades up so that
+                -- the colorsets have more chance to look good with transparent
+                -- background on brighter wallpapers.
+                local old_lightness = bg:get_hsl().l
+                local threshold = 20
+                local baseline = 10
+                if old_lightness < threshold then
+                    -- We will assume that the dimmest of transparent
+                    -- background over users wallpaper is at least of baseline
+                    -- lightness. Presuming old range is [0, threshold], let's
+                    -- position the lightness relatively in a new range of
+                    -- [baseline, threshold].
+                    local position = old_lightness / threshold
+                    local new_lightness = baseline + ((threshold - baseline) * position)
+                    return new_lightness
+                end
+            end,
             floating_windows = true,
             telescope = true,
             file_tree = true,


### PR DESCRIPTION
The background usually becomes lighter when transparent background is enabled. This was noticed and discussed [here](https://github.com/ramojus/mellifluous.nvim/pull/50#issuecomment-2259996719)

The default here is something that works relatively well for the types of wallpapers that I use, while still preserving the style and readability of the colorset quite well.