### PR TITLE
docs(README): add iTerm2-Color-Schemes port

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ Options include:
 - [ ] Support more plugins (contributions are welcome).
 
 ## Ports
-- [Helix (with slightly outdated color palette)](https://github.com/helix-editor/helix/wiki/Themes#meliora)
+- [Helix](https://github.com/helix-editor/helix/wiki/Themes#meliora) (with slightly outdated color palette)
+- [iTerm2](https://github.com/mbadolato/iTerm2-Color-Schemes) (plus additional terminal emulator ports, courtesy of iTerm2-Color-Schemes)
 
 ## Inspiration
 - [Mountain and Mountaineer](https://github.com/mountain-theme/mountain)


### PR DESCRIPTION
Hey @ramojus! Big fan of your theme, and doing everything I can to make it a lifestyle 😀. Some time ago I contributed a port to the [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes?tab=readme-ov-file#mellifluous) project, which in turn provides generated themes for dozens of other terminal emulators and applications. Thought you might want to include it in your links,