### PR TITLE
Add support for nvim-dap-ui controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A colorscheme for [Neovim](https://github.com/neovim/neovim). Pleasant and produ
 - [Neotest](https://github.com/nvim-neotest/neotest)
 - [Lazy](https://github.com/folke/lazy.nvim)
 - [Mason](https://github.com/williamboman/mason.nvim)
+- [Nvim-DAP-UI](https://github.com/rcarriga/nvim-dap-ui) (control panel only)
 
 ## Installation and usage
 Example with [packer.nvim](https://github.com/wbthomason/packer.nvim):

--- a/lua/mellifluous/default_config.lua
+++ b/lua/mellifluous/default_config.lua
@@ -4,6 +4,7 @@ return {
         aerial = true,
         blink_cmp = true,
         cmp = true,
+        dap_ui = true,
         fzf = true,
         gitsigns = true,
         indent_blankline = true,

--- a/lua/mellifluous/highlights/plugins/dap_ui.lua
+++ b/lua/mellifluous/highlights/plugins/dap_ui.lua
@@ -1,0 +1,41 @@
+local M = {}
+
+local function replicate_winbar_shade(hl, target_color)
+    local shader = require("mellifluous.utils.shader")
+    return shader.replicate_shade(hl.get("Normal").bg, hl.get("WinBar").bg, target_color)
+end
+
+local function replicate_winbarnc_shade(hl, target_color)
+    local shader = require("mellifluous.utils.shader")
+    return shader.replicate_shade(hl.get("Normal").bg, hl.get("WinBarNC").bg, target_color)
+end
+
+function M.set(hl, colors)
+    -- Controls
+    local green_ctrl = { bg = hl.get("WinBar").bg, fg = replicate_winbar_shade(hl, colors.ui_green) }
+    local green_ctrl_nc = { bg = hl.get("WinBarNC").bg, fg = replicate_winbarnc_shade(hl, colors.ui_green) }
+    local red_ctrl = { bg = hl.get("WinBar").bg, fg = replicate_winbar_shade(hl, colors.ui_red) }
+    local red_ctrl_nc = { bg = hl.get("WinBarNC").bg, fg = replicate_winbarnc_shade(hl, colors.ui_red) }
+    local blue_ctrl = { bg = hl.get("WinBar").bg, fg = replicate_winbar_shade(hl, colors.ui_blue) }
+    local blue_ctrl_nc = { bg = hl.get("WinBarNC").bg, fg = replicate_winbarnc_shade(hl, colors.ui_blue) }
+    local muted_ctrl = { bg = hl.get("WinBar").bg, fg = replicate_winbar_shade(hl, colors.fg4) }
+    local muted_ctrl_nc = { bg = hl.get("WinBarNC").bg, fg = replicate_winbarnc_shade(hl, colors.fg4) }
+    hl.set("DapUIPlayPause", green_ctrl)
+    hl.set("DapUIPlayPauseNC", green_ctrl_nc)
+    hl.set("DapUIRestart", green_ctrl)
+    hl.set("DapUIRestartNC", green_ctrl_nc)
+    hl.set("DapUIStop", red_ctrl)
+    hl.set("DapUIStopNC", red_ctrl_nc)
+    hl.set("DapUIStepInto", blue_ctrl)
+    hl.set("DapUIStepIntoNC", blue_ctrl_nc)
+    hl.set("DapUIStepOver", blue_ctrl)
+    hl.set("DapUIStepOverNC", blue_ctrl_nc)
+    hl.set("DapUIStepOut", blue_ctrl)
+    hl.set("DapUIStepOutNC", blue_ctrl_nc)
+    hl.set("DapUIStepBack", blue_ctrl)
+    hl.set("DapUIStepBackNC", blue_ctrl_nc)
+    hl.set("DapUIUnavailable", muted_ctrl)
+    hl.set("DapUIUnavailableNC", muted_ctrl_nc)
+end
+
+return M


### PR DESCRIPTION
This PR adds initial customizations for the nvim-dap-ui plugin.

The plugin supports several widgets, however I decided to focus my efforts only on the _Control Panel_ in this PR, to keep the scope small and because it is the only widget which looks broken out of the box. The reason being that nvim-dap-ui assumes that the `WinBar` highlight group has a **concrete** background color set, whereas the group is a link in mellifluous.

- https://github.com/rcarriga/nvim-dap-ui/blob/v4.0.0/lua/dapui/config/highlights.lua#L76-L77
- https://github.com/rcarriga/nvim-dap-ui/blob/v4.0.0/lua/dapui/controls.lua#L19-L27

Before:
<img width="683" alt="inactive_before" src="https://github.com/user-attachments/assets/5e2d2075-4a28-40b6-9bac-4c5f981ccea0" />
<img width="642" alt="active_before" src="https://github.com/user-attachments/assets/3fd5bdd0-10bd-4957-8919-2200ace8bcb0" />
After:
<img width="396" alt="image" src="https://github.com/user-attachments/assets/f4711f3f-15df-499c-b9ad-ebac4657e300" />
<img width="393" alt="image" src="https://github.com/user-attachments/assets/c2b5e711-782b-4597-9a71-e00e087d62fc" />
<img width="395" alt="image" src="https://github.com/user-attachments/assets/df95236d-e8ef-4070-9799-24950c289f48" />
<img width="394" alt="image" src="https://github.com/user-attachments/assets/fc5ecd0f-766b-47ac-8191-40758b7b9d69" />

<details><summary>Outdated screenshots</summary>
<p>

<img width="603" alt="inactive_after" src="https://github.com/user-attachments/assets/31b069c9-4214-46e8-ab16-023caf2f793d" />
<img width="596" alt="active_after" src="https://github.com/user-attachments/assets/10f81cc4-f6fb-4999-b41c-8afd4c544568" />

</p>
</details> 