### PR TITLE
Add support for nvim-dap-ui widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A colorscheme for [Neovim](https://github.com/neovim/neovim). Pleasant and produ
 - [Neotest](https://github.com/nvim-neotest/neotest)
 - [Lazy](https://github.com/folke/lazy.nvim)
 - [Mason](https://github.com/williamboman/mason.nvim)
-- [Nvim-DAP-UI](https://github.com/rcarriga/nvim-dap-ui) (control panel only)
+- [Nvim-DAP-UI](https://github.com/rcarriga/nvim-dap-ui)
 
 ## Installation and usage
 Example with [packer.nvim](https://github.com/wbthomason/packer.nvim):

--- a/lua/mellifluous/highlights/plugins/dap_ui.lua
+++ b/lua/mellifluous/highlights/plugins/dap_ui.lua
@@ -11,6 +11,8 @@ local function replicate_winbarnc_shade(hl, target_color)
 end
 
 function M.set(hl, colors)
+    local groups = require("mellifluous.highlights.custom_groups").get(colors)
+
     -- Controls
     local green_ctrl = { bg = hl.get("WinBar").bg, fg = replicate_winbar_shade(hl, colors.ui_green) }
     local green_ctrl_nc = { bg = hl.get("WinBarNC").bg, fg = replicate_winbarnc_shade(hl, colors.ui_green) }
@@ -36,6 +38,28 @@ function M.set(hl, colors)
     hl.set("DapUIStepBackNC", blue_ctrl_nc)
     hl.set("DapUIUnavailable", muted_ctrl)
     hl.set("DapUIUnavailableNC", muted_ctrl_nc)
+
+    -- Scopes
+    hl.set("DapUIScope", { fg = hl.get("Title").fg })
+    hl.set("DapUIType", { fg = hl.get("Type").fg })
+    hl.set("DapUIVariable", { fg = hl.get("Identifier").fg })
+    hl.set("DapUIModifiedValue", { fg = hl.get("Changed").fg, bold = true })
+    hl.set("DapUIDecoration", groups.IndentLine(colors.bg))
+
+    -- Breakpoints
+    hl.set("DapUIBreakpointsPath", { fg = colors.fg2 })
+    hl.set("DapUILineNumber", { fg = hl.get("Number").fg })
+    hl.set("DapUIBreakpointsCurrentLine", { fg = hl.get("Number").fg, bold = true })
+
+    -- Stacks
+    hl.set("DapUIThread", { fg = colors.green })
+    hl.set("DapUIStoppedThread", { fg = hl.get("Function").fg })
+    hl.set("DapUISource", { fg = colors.fg2 })
+
+    -- Watches
+    hl.set("DapUIWatchesEmpty", { fg = colors.fg3 })
+    hl.set("DapUIWatchesValue", { fg = hl.get("Function").fg })
+    hl.set("DapUIWatchesError", { fg = hl.get("Error").fg })
 end
 
 return M


### PR DESCRIPTION
Follow up to #82

Adds customizations for the rest of nvim-dap-ui's widgets.

---

_overview of DapUI\* highlights_

([defaults](https://github.com/rcarriga/nvim-dap-ui/blob/v4.0.0/lua/dapui/config/highlights.lua#L16-L50) for reference)

<img width="260" alt="hls" src="https://github.com/user-attachments/assets/157ee226-d297-45a8-a835-862fdb28ca44" />

---

_before_
<img width="1517" alt="after" src="https://github.com/user-attachments/assets/95eb6b41-2a24-478b-be94-a8613a24ff51" />

_after_
<img width="1561" alt="before" src="https://github.com/user-attachments/assets/0968ea9a-9f39-4d03-804f-161d3ca41b2f" />