### PR TITLE
fix(highlights): link `@lsp.type.comment` to `Comment`

### DIFF
--- a/lua/mellifluous/highlights/plugins/semantic_tokens.lua
+++ b/lua/mellifluous/highlights/plugins/semantic_tokens.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.set(hl, colors)
     local groups = require("mellifluous.highlights.custom_groups").get(colors)
 
-    hl.set("@lsp.type.comment", {}) -- let treesitter handle those
+    hl.set("@lsp.type.comment", { link = "Comment" })
     hl.set("@lsp.type.enum", { link = "Type" })
     hl.set("@lsp.type.enumMember", { link = "Constant" })
     hl.set("@lsp.type.escapeSequence", { fg = colors.fg3 })


### PR DESCRIPTION
Solves #86

Before:
![image](https://github.com/user-attachments/assets/25a08324-5d1c-4297-9975-4426d5bb8cbe)

After:
![image](https://github.com/user-attachments/assets/718423a5-ea74-44c2-8634-29e9d24bee9c)
