### PR TITLE
fix(highlights): link `@lsp.type.macro` to `Macro`

### DIFF
--- a/lua/mellifluous/highlights/plugins/semantic_tokens.lua
+++ b/lua/mellifluous/highlights/plugins/semantic_tokens.lua
@@ -13,6 +13,7 @@ function M.set(hl, colors)
     hl.set("@lsp.type.parameter", {})
     hl.set("@lsp.type.property", { fg = colors.fg })
     hl.set("@lsp.type.variable", {})
+    hl.set("@lsp.type.macro", { link = "Macro" })
     hl.set("@lsp.typemod.variable.constant", { link = "Constant" })
     hl.set("@lsp.typemod.keyword.controlFlow", groups.MainKeyword)
 end


### PR DESCRIPTION
It was one of my core principles when designing this colorscheme, that even macros, for simplicity, should still look like a function - they are usually differentiated syntactically anyways.