### PR TITLE
Customize fzf-lua live prompt

### DIFF
--- a/lua/mellifluous/highlights/plugins/fzf.lua
+++ b/lua/mellifluous/highlights/plugins/fzf.lua
@@ -53,6 +53,7 @@ function M.set(hl, colors)
     })
     hl.set("FzfLuaFzfMarker", { fg = colors.ui_orange })
     hl.set("FzfLuaFzfPrompt", { fg = colors.fg4 })
+    hl.set("FzfLuaLivePrompt", { fg = colors.red })
     hl.set("FzfLuaFzfQuery", { fg = colors.fg })
     hl.set("FzfLuaBackdrop", groups.Backdrop)
 end


### PR DESCRIPTION
The prompt for live queries (e.g. `:Fzf live_grep`) currently stands out as [PaleVioletRed1](https://github.com/neovim/neovim/blob/v0.11.3/src/nvim/highlight_group.c#L2992) `#ff82ab`, which is blatantly off-palette:

<img width="1151" height="643" alt="before" src="https://github.com/user-attachments/assets/85ba48cc-671c-43c7-bc7c-dc8e7bf932b3" />

This PR sets a foreground color from the colorscheme's palette for `FzfLuaLivePrompt`:

<img width="883" height="392" alt="image" src="https://github.com/user-attachments/assets/87f7cb87-3b44-405b-970e-ff30302adf49" />

<details><summary>Outdated screenshot :art:</summary>
<p>

<img width="1151" height="643" alt="after" src="https://github.com/user-attachments/assets/47b4cfed-ef29-40cd-bc64-1f772bc22826" />

</p>
</details> 

This highlight was added in https://github.com/ibhagwan/fzf-lua/commit/2bbda79c7f4f836d8a75ff554ac4805c49ab06a3.