### PR TITLE
Highlight OkMsg

### DIFF
--- a/lua/mellifluous/highlights/general.lua
+++ b/lua/mellifluous/highlights/general.lua
@@ -34,6 +34,7 @@ function M.set(hl, colors)
     hl.set("EndOfBuffer", { fg = colors.bg }) -- Filler lines (~) after the end of the buffer. By default, this is highlighted like |hl-NonText|.
     hl.set("TermCursor", { link = "Cursor" }) -- Cursor in a focused terminal
     hl.set("TermCursorNC", { bg = colors.fg5 }) -- Cursor in an unfocused terminal
+    hl.set("OkMsg", { fg = colors.green }) -- Success messages
     hl.set("ErrorMsg", { fg = colors.red }) -- Error messages on the command line
     hl.set("VertSplit", {
         fg = colors.fg5,


### PR DESCRIPTION
Used for success messages. neovim/neovim@8a12a01

Defaults to `NvimDarkGreen`:

<img width="377" height="56" alt="before" src="https://github.com/user-attachments/assets/d003eb35-8c28-4d27-bed1-101826b81447" />
