### PR TITLE
Fix gitcommit heading conflicting with Spell

### DIFF
--- a/lua/mellifluous/highlights/plugins/treesitter.lua
+++ b/lua/mellifluous/highlights/plugins/treesitter.lua
@@ -147,7 +147,7 @@ function M.set(hl, colors)
         style = config.styles.markup.headings,
     })
     hl.set("@markup.heading", { link = "@markup.heading.1" })
-    hl.set("@markup.heading.gitcommit", { fg = hl.get("@markup.heading").fg })
+    hl.set("@markup.heading.gitcommit", { link = "@string" })
     hl.set("@markup.heading.1.vimdoc", { fg = hl.get("@markup.heading").fg })
     hl.set("@markup.heading.2.vimdoc", { fg = hl.get("@markup.heading").fg })
     hl.set("@markup.heading.3.vimdoc", { fg = hl.get("@markup.heading").fg })


### PR DESCRIPTION
_tl;dr_

**Problem:** `@markup.heading.gitcommit` uses red as foreground color, which conflicts with the color used by the spell checker. So when a word is legitimately misspelled, it can't be told apart from the rest of the text.

**Solution:** use a different accent color in commit titles.

_gitcommit highlights before_

<img width="705" height="30" alt="spell_before" src="https://github.com/user-attachments/assets/9ae5ca30-e700-4a86-954c-d3b0185774ac" />

_gitcommit highlights after_

<img width="716" height="27" alt="spell_after" src="https://github.com/user-attachments/assets/4c124f79-42eb-4eca-946d-5004fc4e3895" />

---

<details><summary>Long version</summary>
<p>

With Tree-sitter highlights enabled inside `gitcommit` files (using the [gitcommit grammar](https://github.com/gbprod/tree-sitter-gitcommit)), commit titles are highlighted as follows:

```
Treesitter
  - @markup.heading.gitcommit priority: 100   language: gitcommit
  - @spell.gitcommit links to @spell   priority: 100   language: gitcommit
```

`@markup.heading.gitcommit` currently has the same foreground color as Markdown H1 headings, red, which conflicts with the spell checker's foreground color.
This is problematic because enabling the spell checker in Git commits is common and encouraged.

This problem does not occur with the Vim (legacy) syntax, which uses the Keyword highlight group (yellow) on the entire line:

```
:hi gitcommitSummary
gitcommitSummary xxx links to Keyword
```

---

_Full before/after overview_

<img width="707" height="372" alt="before" src="https://github.com/user-attachments/assets/3d86ca10-4a81-4b16-a83c-de7c576eade7" />

<img width="715" height="432" alt="after" src="https://github.com/user-attachments/assets/b8e93fa5-b461-4132-aa89-4792fdfddf0d" />


</p>
</details> 

---

**Additional observation**



Mellifluous follows the `config.styles.markup.headings` option for styling markup headings, which defaults to bold (same as Neovim's default). I see that `gitcommit` headings do not honor that option (intentionally?).

For the experiment, here is how commit titles look like when bold:

<img width="701" height="23" alt="bold" src="https://github.com/user-attachments/assets/4b76543b-5458-4b62-ac0b-fa4b652acde8" />

I think the style is fitting. Would you consider such change in a follow up PR?