### PR TITLE
Honor `markup.headings` style in gitcommit heading

### DIFF
--- a/lua/mellifluous/highlights/plugins/treesitter.lua
+++ b/lua/mellifluous/highlights/plugins/treesitter.lua
@@ -147,7 +147,10 @@ function M.set(hl, colors)
         style = config.styles.markup.headings,
     })
     hl.set("@markup.heading", { link = "@markup.heading.1" })
-    hl.set("@markup.heading.gitcommit", { link = "@string" })
+    hl.set("@markup.heading.gitcommit", {
+        fg = hl.get("@string").fg,
+        style = config.styles.markup.headings,
+    })
     hl.set("@markup.heading.1.vimdoc", { fg = hl.get("@markup.heading").fg })
     hl.set("@markup.heading.2.vimdoc", { fg = hl.get("@markup.heading").fg })
     hl.set("@markup.heading.3.vimdoc", { fg = hl.get("@markup.heading").fg })


### PR DESCRIPTION
Follow up to #94

Makes Git commit titles bold if the user has configured markup headings to be bold (using the `config.styles.markup.headings` option).

<img width="1225" height="774" alt="git title bold" src="https://github.com/user-attachments/assets/07a88265-0896-49e9-bb3a-379bbfdf86b7" />